### PR TITLE
[Feature] Refactor HomeScreen to use HomeViewModel for state management and added loading indicator

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
             implementation(libs.coil.network.ktor)
             implementation(libs.ktor.client.core)
             implementation(libs.androidx.navigation.compose)
+            implementation(libs.androidx.lifecycle.viewmodel.compose)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui.screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui.screens/home/HomeScreen.kt
@@ -2,14 +2,17 @@ package org.example.kmpmovies.ui.screens.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -17,23 +20,27 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import kmpmovies.composeapp.generated.resources.Res
 import kmpmovies.composeapp.generated.resources.app_name
 import org.example.kmpmovies.Movie
-import org.example.kmpmovies.movies
 import org.example.kmpmovies.ui.screens.Screen
 import org.jetbrains.compose.resources.stringResource
 
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(onMovieClick: (Movie) -> Unit) {
+fun HomeScreen(
+    onMovieClick: (Movie) -> Unit,
+    vm: HomeViewModel = viewModel { HomeViewModel() } // esto sirve para no recrear el VM cada que haya recomposiciones o cambios, y reutilizar el que se había creado originalmente
+) {
     Screen {
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         Scaffold(
@@ -46,6 +53,15 @@ fun HomeScreen(onMovieClick: (Movie) -> Unit) {
             modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
         )
         { padding ->
+            val state = vm.state
+            if (state.loading) {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(padding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(120.dp),
                 contentPadding = PaddingValues(4.dp),
@@ -53,7 +69,7 @@ fun HomeScreen(onMovieClick: (Movie) -> Unit) {
                 verticalArrangement = Arrangement.spacedBy(4.dp),
                 modifier = Modifier.padding(padding)
             ) {
-                items(movies, key = { it.id }) {
+                items(state.movies, key = { it.id }) {
                     MovieItem(movie = it, onClick = { onMovieClick(it) })
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui.screens/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui.screens/home/HomeViewModel.kt
@@ -1,0 +1,28 @@
+package org.example.kmpmovies.ui.screens.home
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.example.kmpmovies.Movie
+import org.example.kmpmovies.movies
+
+class HomeViewModel : ViewModel() {
+    var state by mutableStateOf(UiState())
+        private set
+
+    init {
+        viewModelScope.launch {
+            state = UiState(loading = true)
+            delay(1000)
+            state = UiState(loading = false, movies = movies)
+        }
+    }
+    data class UiState(
+        val loading: Boolean = false,
+        val movies: List<Movie> = emptyList()
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlin = "2.0.0"
 coil = "3.0.0-alpha06"
 ktor = "2.3.11"
 navigation-compose = "2.8.0-alpha02"
+androidx-lifecycle = "2.8.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -34,6 +35,7 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref =
 ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
 androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
+androidx-lifecycle-viewmodel-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Description
In this PR, I updated the HomeScreen function to accept a HomeViewModel instance as a parameter, ensuring that the ViewModel is reused across recompositions. I added logic to display a loading indicator while data is being fetched.

Additionally, I modified the LazyVerticalGrid to use state.movies instead of the original movies list, allowing for dynamic updates based on the ViewModel's state.

## Screenshot / Video


https://github.com/user-attachments/assets/71c9716b-51f1-42cf-a301-9d51ceee18fa



