### PR TITLE
[Feature] Refactor API key management using BuildConfig and remove api_key.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ out/
 *.klib
 kotlin-compile-*
 .kotlin/sessions/*.salive
-api_key.xml
 
 # IntelliJ IDEA
 .idea/

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -10,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.androidxRoom)
+    alias(libs.plugins.gradleBuildConfig)
 }
 
 kotlin {
@@ -113,4 +115,14 @@ tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().configureEach
 
 room {
     schemaDirectory("$projectDir/schemas")
+}
+
+buildConfig {
+    packageName("org.example.kmpmovies")
+
+    val properties = Properties()
+    properties.load(project.rootProject.file("local.properties").reader())
+    val apiKey = properties.getProperty("API_KEY")
+
+    buildConfigField("API_KEY", apiKey)
 }

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/Navigation.kt
@@ -13,9 +13,8 @@ import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.URLProtocol
 import io.ktor.serialization.kotlinx.json.json
-import kmpmovies.composeapp.generated.resources.Res
-import kmpmovies.composeapp.generated.resources.api_key
 import kotlinx.serialization.json.Json
+import org.example.kmpmovies.BuildConfig
 import org.example.kmpmovies.data.MoviesRepository
 import org.example.kmpmovies.data.MoviesService
 import org.example.kmpmovies.data.database.MoviesDao
@@ -23,7 +22,6 @@ import org.example.kmpmovies.ui.screens.detail.DetailScreen
 import org.example.kmpmovies.ui.screens.detail.DetailViewModel
 import org.example.kmpmovies.ui.screens.home.HomeScreen
 import org.example.kmpmovies.ui.screens.home.HomeViewModel
-import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun Navigation(moviesDao: MoviesDao) {
@@ -53,10 +51,7 @@ fun Navigation(moviesDao: MoviesDao) {
 }
 
 @Composable
-private fun rememberMoviesRepository(
-    moviesDao: MoviesDao,
-    apiKey: String = stringResource(Res.string.api_key)
-): MoviesRepository = remember {
+private fun rememberMoviesRepository(moviesDao: MoviesDao): MoviesRepository = remember {
     val client = HttpClient {
         install(ContentNegotiation) {
             json(Json {
@@ -68,7 +63,7 @@ private fun rememberMoviesRepository(
             url {
                 protocol = URLProtocol.HTTPS
                 host = "api.themoviedb.org"
-                parameters.append("api_key", apiKey)
+                parameters.append("api_key", BuildConfig.API_KEY)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidx-lifecycle = "2.8.0"
 ksp = "2.0.0-1.0.21"
 androidx-room = "2.7.0-alpha03"
 androidx-sqliteBundled = "2.5.0-alpha03"
+buildconfig = "5.3.5"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -54,3 +55,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidxRoom = { id = "androidx.room", version.ref = "androidx-room" }
+gradleBuildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }


### PR DESCRIPTION
## Description
In this pull request, I improved the management of the API key by moving it from the XML file to the local.properties file. This change allows for better integration with dependency injection and enhances compatibility across different platforms. I added the necessary configuration in build.gradle to load the API key into BuildConfig, making it accessible throughout the project. Additionally, I removed api_key.xml from .gitignore and deleted the file to streamline the project structure. Now, in the rememberMoviesRepository() function, I can retrieve the API key directly using BuildConfig.API_KEY, simplifying the code and improving maintainability.

## Screenshot / Video

![image](https://github.com/user-attachments/assets/eb243742-23af-419b-b7d4-2e7225a6bba7)

