### PR TITLE
[Feature] Set up Koin for dependency injection

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.koin.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -56,6 +57,10 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.room.runtime)
             implementation(libs.androidx.sqlite.bundled)
+            implementation(project.dependencies.platform(libs.koin.bom))
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".MoviesApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/composeApp/src/androidMain/kotlin/org/example/kmpmovies/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/example/kmpmovies/MainActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-import org.example.kmpmovies.data.database.getDatabaseBuilder
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,8 +18,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge() // permite pintar hasta los bordes
         setContent {
             EnableTransparentStatusBar()
-            val db = getDatabaseBuilder(this).build()
-            App(db.moviesDao())
+            App()
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/example/kmpmovies/MoviesApp.kt
+++ b/composeApp/src/androidMain/kotlin/org/example/kmpmovies/MoviesApp.kt
@@ -1,0 +1,16 @@
+package org.example.kmpmovies
+
+import android.app.Application
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.logger.Level
+
+class MoviesApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        initKoin {
+            androidLogger(Level.DEBUG)
+            androidContext(this@MoviesApp)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/example/kmpmovies/di.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/example/kmpmovies/di.android.kt
@@ -1,0 +1,8 @@
+package org.example.kmpmovies
+
+import org.example.kmpmovies.data.database.getDatabaseBuilder
+import org.koin.dsl.module
+
+actual val nativeModule = module {
+    single { getDatabaseBuilder(get()) }
+}

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/App.kt
@@ -6,19 +6,18 @@ import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.crossfade
 import coil3.util.DebugLogger
-import org.example.kmpmovies.data.database.MoviesDao
 import org.example.kmpmovies.ui.screens.Navigation
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 @Preview
-fun App(moviesDao: MoviesDao) {
+fun App() {
     setSingletonImageLoaderFactory { context ->
         ImageLoader.Builder(context)
             .crossfade(true)
             .logger(DebugLogger())
             .build()
     }
-    Navigation(moviesDao)
+    Navigation()
 }

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/di.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/di.kt
@@ -1,0 +1,66 @@
+package org.example.kmpmovies
+
+import androidx.room.RoomDatabase
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.URLProtocol
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import org.example.kmpmovies.data.MoviesRepository
+import org.example.kmpmovies.data.MoviesService
+import org.example.kmpmovies.data.database.MoviesDao
+import org.example.kmpmovies.data.database.MoviesDataBase
+import org.example.kmpmovies.ui.screens.detail.DetailViewModel
+import org.example.kmpmovies.ui.screens.home.HomeViewModel
+import org.koin.compose.viewmodel.dsl.viewModelOf
+import org.koin.core.context.startKoin
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.KoinAppDeclaration
+
+val appModule = module {
+    single(named("apikey")) { BuildConfig.API_KEY }
+    single<MoviesDao> {
+        val dbBuilder = get<RoomDatabase.Builder<MoviesDataBase>>()
+        dbBuilder.build().moviesDao()
+    }
+}
+
+val dataModule = module {
+    factoryOf(::MoviesRepository)
+    factoryOf(::MoviesService)
+    single {
+        HttpClient {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys =
+                        true // Es para no recibir una excepcion ya que no se parcea el JSON completo
+                })
+            }
+            install(DefaultRequest) {
+                url {
+                    protocol = URLProtocol.HTTPS
+                    host = "api.themoviedb.org"
+                    parameters.append("api_key", BuildConfig.API_KEY)
+                }
+            }
+        }
+    }
+}
+
+val viewModelsModule = module {
+    viewModelOf(::HomeViewModel)
+    viewModelOf(::DetailViewModel)
+}
+
+expect val nativeModule: Module
+
+fun initKoin(config: KoinAppDeclaration? = null) {
+    startKoin {
+        config?.invoke(this)
+        modules(appModule, dataModule, viewModelsModule, nativeModule)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/Navigation.kt
@@ -1,40 +1,28 @@
 package org.example.kmpmovies.ui.screens
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.DefaultRequest
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.http.URLProtocol
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
-import org.example.kmpmovies.BuildConfig
-import org.example.kmpmovies.data.MoviesRepository
-import org.example.kmpmovies.data.MoviesService
-import org.example.kmpmovies.data.database.MoviesDao
 import org.example.kmpmovies.ui.screens.detail.DetailScreen
-import org.example.kmpmovies.ui.screens.detail.DetailViewModel
 import org.example.kmpmovies.ui.screens.home.HomeScreen
-import org.example.kmpmovies.ui.screens.home.HomeViewModel
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.parameter.parametersOf
 
+@OptIn(KoinExperimentalAPI::class)
 @Composable
-fun Navigation(moviesDao: MoviesDao) {
+fun Navigation() {
     val navController = rememberNavController()
-    val repository = rememberMoviesRepository(moviesDao)
 
     NavHost(navController = navController, startDestination = "home") {
         composable("home") {
             HomeScreen(
                 onMovieClick = { movie ->
                     navController.navigate("details/${movie.id}")
-                },
-                vm = viewModel { HomeViewModel(repository) }
+                }
             )
         }
         composable(
@@ -43,29 +31,9 @@ fun Navigation(moviesDao: MoviesDao) {
         ) { backStackEntry ->
             val movieId = checkNotNull(backStackEntry.arguments?.getInt("movieId"))
             DetailScreen(
-                vm = viewModel { DetailViewModel(movieId,repository) },
+                vm = koinViewModel(parameters = { parametersOf(movieId) }),
                 onBack = { navController.popBackStack() }
             )
         }
     }
-}
-
-@Composable
-private fun rememberMoviesRepository(moviesDao: MoviesDao): MoviesRepository = remember {
-    val client = HttpClient {
-        install(ContentNegotiation) {
-            json(Json {
-                ignoreUnknownKeys =
-                    true // Es para no recibir una excepcion ya que no se parcea el JSON completo
-            })
-        }
-        install(DefaultRequest) {
-            url {
-                protocol = URLProtocol.HTTPS
-                host = "api.themoviedb.org"
-                parameters.append("api_key", BuildConfig.API_KEY)
-            }
-        }
-    }
-    MoviesRepository(MoviesService(client), moviesDao)
 }

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/home/HomeScreen.kt
@@ -29,12 +29,14 @@ import org.example.kmpmovies.data.Movie
 import org.example.kmpmovies.ui.common.LoadingIndicator
 import org.example.kmpmovies.ui.screens.Screen
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, KoinExperimentalAPI::class)
 @Composable
 fun HomeScreen(
     onMovieClick: (Movie) -> Unit,
-    vm: HomeViewModel
+    vm: HomeViewModel = koinViewModel()
 ) {
     Screen {
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()

--- a/composeApp/src/iosMain/kotlin/org/example/kmpmovies/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/example/kmpmovies/MainViewController.kt
@@ -1,9 +1,9 @@
 package org.example.kmpmovies
 
 import androidx.compose.ui.window.ComposeUIViewController
-import org.example.kmpmovies.data.database.getDatabaseBuilder
 
-fun MainViewController() = ComposeUIViewController {
-    val database = getDatabaseBuilder().build()
-    App(database.moviesDao())
+fun MainViewController() = ComposeUIViewController(
+    configure = { initKoin() }
+) {
+    App()
 }

--- a/composeApp/src/iosMain/kotlin/org/example/kmpmovies/di.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/example/kmpmovies/di.ios.kt
@@ -1,0 +1,8 @@
+package org.example.kmpmovies
+
+import org.example.kmpmovies.data.database.getDatabaseBuilder
+import org.koin.dsl.module
+
+actual val nativeModule = module {
+    single { getDatabaseBuilder() }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ ksp = "2.0.0-1.0.21"
 androidx-room = "2.7.0-alpha03"
 androidx-sqliteBundled = "2.5.0-alpha03"
 buildconfig = "5.3.5"
+koin = "3.6.0-Beta4"
+koinCompose = "1.2.0-Beta4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -45,6 +47,11 @@ androidx-lifecycle-viewmodel-compose = { group = "org.jetbrains.androidx.lifecyc
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidx-room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }
 androidx-sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "androidx-sqliteBundled" }
+koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
+koin-android = { group = "io.insert-koin", name = "koin-android" }
+koin-core = { group = "io.insert-koin", name = "koin-core" }
+koin-compose = { group = "io.insert-koin", name = "koin-compose" }
+koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koinCompose"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Description
In this pull request, I implemented Koin as the dependency injection framework, as neither Dagger nor Hilt are supported in KMP. I configured Koin by adding the necessary dependencies in the libs and build.gradle files. I created a dedicated DI file to define our modules, including appModule, dataModule, and viewModelsModule.

Additionally, I set up the nativeModule for both Android and iOS, ensuring that the database builder is correctly initialized for each platform. I created the MoviesApp class to initialize Koin in the application context and updated the AndroidManifest.xml accordingly. Finally, I removed moviesDao from Navigation and adjusted the ViewModel instantiation in both the HomeScreen and DetailScreen to use Koin, streamlining our dependency management.

## Screenshot / Video

https://github.com/user-attachments/assets/354724bf-5d6b-45d9-9428-63da37228c9f

