### PR TITLE
[Feature] Implement favorite movie toggle and update UI in Home and Detail screens

### DIFF
--- a/composeApp/schemas/org.example.kmpmovies.data.database.MoviesDataBase/1.json
+++ b/composeApp/schemas/org.example.kmpmovies.data.database.MoviesDataBase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "c189a27957d05862fae5f30752fa7581",
+    "identityHash": "caca85dc4dd8f1bf51030029c5ab6df2",
     "entities": [
       {
         "tableName": "Movie",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `overview` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `poster` TEXT NOT NULL, `backdrop` TEXT, `originalTitle` TEXT NOT NULL, `originalLanguage` TEXT NOT NULL, `popularity` REAL NOT NULL, `voteAverage` REAL NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `overview` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `poster` TEXT NOT NULL, `backdrop` TEXT, `originalTitle` TEXT NOT NULL, `originalLanguage` TEXT NOT NULL, `popularity` REAL NOT NULL, `voteAverage` REAL NOT NULL, `isFavorite` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -66,6 +66,12 @@
             "columnName": "voteAverage",
             "affinity": "REAL",
             "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -78,7 +84,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c189a27957d05862fae5f30752fa7581')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'caca85dc4dd8f1bf51030029c5ab6df2')"
     ]
   }
 }

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -6,4 +6,5 @@
     <string name="release_date">Fecha de lanzamiento</string>
     <string name="popularity">Popularidad</string>
     <string name="vote_average">Promedio de votos</string>
+    <string name="favorite">Marcado como Favorito</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="release_date">Release date</string>
     <string name="popularity">Popularity</string>
     <string name="vote_average">Vote average</string>
+    <string name="favorite">Mark as Favorite</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/data/Movie.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/data/Movie.kt
@@ -15,5 +15,6 @@ data class Movie(
     val originalTitle: String,
     val originalLanguage: String,
     val popularity: Double,
-    val voteAverage: Double
+    val voteAverage: Double,
+    val isFavorite: Boolean
 )

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/data/MoviesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/data/MoviesRepository.kt
@@ -25,6 +25,10 @@ class MoviesRepository(
             }
 
         }
+
+    suspend fun toggleFavorite(movie: Movie) {
+        moviesDao.save(listOf(movie.copy(isFavorite = !movie.isFavorite)))
+    }
 }
 
 private fun RemoteMovie.toDomainMovie() = Movie(
@@ -37,5 +41,6 @@ private fun RemoteMovie.toDomainMovie() = Movie(
     originalTitle = originalTitle,
     originalLanguage = originalLanguage,
     popularity = popularity,
-    voteAverage = voteAverage
+    voteAverage = voteAverage,
+    isFavorite = false
 )

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/detail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/detail/DetailScreen.kt
@@ -2,7 +2,6 @@ package org.example.kmpmovies.ui.screens.detail
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,7 +9,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +35,7 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import kmpmovies.composeapp.generated.resources.Res
 import kmpmovies.composeapp.generated.resources.back
+import kmpmovies.composeapp.generated.resources.favorite
 import kmpmovies.composeapp.generated.resources.original_language
 import kmpmovies.composeapp.generated.resources.original_title
 import kmpmovies.composeapp.generated.resources.popularity
@@ -59,6 +62,22 @@ fun DetailScreen(
                     onBack = onBack,
                     scrollBehavior = scrollBehavior
                 )
+            },
+            floatingActionButton = {
+                state.movie?.let { movie ->
+                    FloatingActionButton(
+                        onClick = vm::onFavoriteClick
+                    ) {
+                        Icon(
+                            imageVector = if (movie.isFavorite) {
+                                Icons.Default.Favorite
+                            } else {
+                                Icons.Default.FavoriteBorder
+                            },
+                            contentDescription = stringResource(Res.string.favorite)
+                        )
+                    }
+                }
             }
         ) { padding ->
             LoadingIndicator(
@@ -124,7 +143,11 @@ private fun MovieDetail(
                 property(stringResource(Res.string.original_title), movie.originalTitle)
                 property(stringResource(Res.string.release_date), movie.releaseDate)
                 property(stringResource(Res.string.popularity), movie.popularity.toString())
-                property(stringResource(Res.string.vote_average), movie.voteAverage.toString(), end = true)
+                property(
+                    stringResource(Res.string.vote_average),
+                    movie.voteAverage.toString(),
+                    end = true
+                )
             },
             modifier = Modifier
                 .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/detail/DetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/detail/DetailViewModel.kt
@@ -29,4 +29,12 @@ class DetailViewModel(
         val loading: Boolean = false,
         val movie: Movie? = null
     )
+
+    fun onFavoriteClick() {
+        state.movie?.let {
+            viewModelScope.launch {
+                repository.toggleFavorite(it)
+            }
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/example/kmpmovies/ui/screens/home/HomeScreen.kt
@@ -2,6 +2,7 @@ package org.example.kmpmovies.ui.screens.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
@@ -10,13 +11,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -25,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import kmpmovies.composeapp.generated.resources.Res
 import kmpmovies.composeapp.generated.resources.app_name
+import kmpmovies.composeapp.generated.resources.favorite
 import org.example.kmpmovies.data.Movie
 import org.example.kmpmovies.ui.common.LoadingIndicator
 import org.example.kmpmovies.ui.screens.Screen
@@ -72,15 +78,28 @@ fun MovieItem(movie: Movie, onClick: () -> Unit) {
     Column(
         modifier = Modifier.clickable(onClick = onClick)
     ) {
-        AsyncImage(
-            model = movie.poster,
-            contentDescription = movie.title,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(2 / 3f)
-                .clip(MaterialTheme.shapes.small)
-        )
+        Box {
+            AsyncImage(
+                model = movie.poster,
+                contentDescription = movie.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(2 / 3f)
+                    .clip(MaterialTheme.shapes.small)
+            )
+
+            if (movie.isFavorite) {
+                Icon(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription = stringResource(Res.string.favorite),
+                    tint = MaterialTheme.colorScheme.inverseOnSurface,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                )
+            }
+        }
         Text(
             text = movie.title,
             style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
## Description
In this pull request, I implemented the feature to mark movies as favorites. From the DetailScreen, users can now tap a floating action button to toggle a movie's favorite status. I updated the Movie data class to include an isFavorite field and ensured the default value is set to false when fetched from the server.

I created the onFavoriteClick function in the DetailViewModel to handle the toggle logic and added a new method in the MoviesRepository to update the local database. On the HomeScreen, I modified the MovieItem UI to display a favorite icon on top of the poster image when the movie is marked as favorite. This allows users to easily identify their favorite movies at a glance.

## Screenshot / Video

https://github.com/user-attachments/assets/71ffd2e8-ae19-4701-a2e6-593fa74accb2


